### PR TITLE
Debian Bookworm: Fixed Bug in dhclient.conf and generation of machine-id

### DIFF
--- a/files/cloudinit-bookworm-fix.cfg
+++ b/files/cloudinit-bookworm-fix.cfg
@@ -1,0 +1,4 @@
+bootcmd:
+  - [ /usr/bin/dbus-uuidgen, --ensure=/etc/machine-id ]
+  - [ /usr/bin/sed, -i, 's/send host-name/send fqdn.fqdn/g', /etc/dhcp/dhclient.conf ]
+  - [ /usr/bin/systemctl, restart, systemd-networkd ]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,21 +75,39 @@
         dest: "/tmp/{{ proxmox_cloudimage_filename }}"
         checksum: "{{ proxmox_cloudimage_hashtype }}:{{ proxmox_cloudimage_checksum }}"
         mode: 0644
-    - block:
-      - name: install libguestfs-tools
-        ansible.builtin.apt:
-          name: libguestfs-tools
-          state: present
-      - name: add qemu-guest-agent
-        ansible.builtin.command: virt-customize -a /tmp/{{ proxmox_cloudimage_filename }} --install qemu-guest-agent
-        changed_when: true
+
+    - name: install libguestfs-tools
+      ansible.builtin.apt:
+        name: libguestfs-tools
+        state: present
+      when: proxmox_cloudimage_qemuagent or proxmox_cloudimage_repo_subdir == "bookworm"
+
+    - name: add qemu-guest-agent
+      ansible.builtin.command: virt-customize -a /tmp/{{ proxmox_cloudimage_filename }} --install qemu-guest-agent
+      changed_when: true
       when: proxmox_cloudimage_qemuagent
+    - name: regenerate machine-id
+      when: proxmox_cloudimage_repo_subdir == "bookworm"
+      block:
+      - name: remove /etc/machine-id
+        ansible.builtin.command: virt-customize -a /tmp/{{ proxmox_cloudimage_filename }} --delete /etc/machine-id
+        changed_when: true
+
+      - name: copy cludinit-config to temporary directory
+        ansible.builtin.copy:
+          src: cloudinit-bookworm-fix.cfg
+          dest: /tmp/99-bookworm-fix.cfg
+          owner: root
+          group: root
+          mode: 0644
+
+      - name: add cloudimageconfig
+        ansible.builtin.command: virt-customize -a /tmp/{{ proxmox_cloudimage_filename }} --copy-in /tmp/99-bookworm-fix.cfg:/etc/cloud/cloud.cfg.d
 
     - name: set import facts
       ansible.builtin.set_fact:
         proxmox_cloudimage_import_args: --format {{ proxmox_cloudimage_format }}
       when: proxmox_cloudimage_format in ['raw', 'qcow2', 'vmdk']
-
     - name: set import facts
       ansible.builtin.set_fact:
         proxmox_cloudimage_import_args: ""
@@ -127,5 +145,10 @@
         path: "/tmp/{{ proxmox_cloudimage_filename }}"
         state: absent
       when: not proxmox_cloudimage_keep
+
+    - name: remove cloudinit fix
+      ansible.builtin.file:
+        path: /tmp/99-bookworm-fix.cfg
+        state: absent
 
   when: not proxmox_cloudimage_template_existed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,20 +80,21 @@
       ansible.builtin.apt:
         name: libguestfs-tools
         state: present
-      when: proxmox_cloudimage_qemuagent or proxmox_cloudimage_repo_subdir == "bookworm"
+      when: proxmox_cloudimage_qemuagent or 'bookworm' in proxmox_cloudimage_repo_subdir
 
     - name: add qemu-guest-agent
       ansible.builtin.command: virt-customize -a /tmp/{{ proxmox_cloudimage_filename }} --install qemu-guest-agent
       changed_when: true
       when: proxmox_cloudimage_qemuagent
+
     - name: regenerate machine-id
-      when: proxmox_cloudimage_repo_subdir == "bookworm"
+      when: "'bookworm' in proxmox_cloudimage_repo_subdir"
       block:
       - name: remove /etc/machine-id
         ansible.builtin.command: virt-customize -a /tmp/{{ proxmox_cloudimage_filename }} --delete /etc/machine-id
         changed_when: true
 
-      - name: copy cludinit-config to temporary directory
+      - name: copy cloudinit-config to temporary directory
         ansible.builtin.copy:
           src: cloudinit-bookworm-fix.cfg
           dest: /tmp/99-bookworm-fix.cfg
@@ -102,12 +103,15 @@
           mode: 0644
 
       - name: add cloudimageconfig
-        ansible.builtin.command: virt-customize -a /tmp/{{ proxmox_cloudimage_filename }} --copy-in /tmp/99-bookworm-fix.cfg:/etc/cloud/cloud.cfg.d
+        ansible.builtin.command: 
+          cmd: virt-customize -a /tmp/{{ proxmox_cloudimage_filename }} --copy-in /tmp/99-bookworm-fix.cfg:/etc/cloud/cloud.cfg.d
+        changed_when: true
 
     - name: set import facts
       ansible.builtin.set_fact:
         proxmox_cloudimage_import_args: --format {{ proxmox_cloudimage_format }}
       when: proxmox_cloudimage_format in ['raw', 'qcow2', 'vmdk']
+
     - name: set import facts
       ansible.builtin.set_fact:
         proxmox_cloudimage_import_args: ""


### PR DESCRIPTION
in dhclient.conf the original line:
send host-name = gethostname();

will send the fqdn of the machine, marked as just the hostname.
The line is now changed to mark the value correct.

In Debian Bookworm, due to a bug in cloud-init 22.4, the machine-id will not be recreated at the first boot.
This fix will delete the machine-id in the original cloudimage and recreates the id on the first boot